### PR TITLE
Add link to tutorial on main website

### DIFF
--- a/opencage_geocoder/metadata.txt
+++ b/opencage_geocoder/metadata.txt
@@ -1,6 +1,8 @@
 # This file contains metadata for your plugin.
+# https://docs.qgis.org/3.28/en/docs/pyqgis_developer_cookbook/plugins/plugins.html#plugin-metadata-table
 
-# This file should be included when you package your plugin.# Mandatory items:
+# This file should be included when you package your plugin.
+# Mandatory items:
 
 [general]
 name=OpenCage Geocoder
@@ -28,7 +30,6 @@ tags=python,geocoding,forward geocoder,reverse geocoder,addresses
 homepage=https://opencagedata.com/
 category=Analysis
 icon=icon.png
-# experimental flag
 experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version)

--- a/opencage_geocoder/processing/forward.py
+++ b/opencage_geocoder/processing/forward.py
@@ -292,7 +292,7 @@ class ForwardGeocode(QgsProcessingAlgorithm):
         """
         Returns a localised short help string for the algorithm.
         """
-        return self.tr('Convert addresses (e.g.: city names, place names, countries, postcodes or other form of location tag in human language) to point geometries. This process is also known as <a href="https://opencagedata.com/faq">forward geocoding</a>. <br>The original address used for geocoding is appended as an attribute in the output file; for information about the other attributes, please check the help.')
+        return self.tr('<p>Convert addresses (e.g.: city names, place names, countries, postcodes or other form of location text in human language) to point geometries. This process is also known as forward geocoding.</p> <p>The original address used for geocoding is appended as an attribute in the output file.</p><p>For information about the other attributes, please check the help and <a href="https://opencagedata.com/tutorials/geocode-in-qgis">tutorial</a></p>.')
     
     def helpString(self):
         """

--- a/opencage_geocoder/processing/reverse.py
+++ b/opencage_geocoder/processing/reverse.py
@@ -258,7 +258,7 @@ class ReverseGeocode(QgsProcessingAlgorithm):
         """
         Returns a localised short help string for the algorithm.
         """
-        return self.tr('Turn point geometries into human understandable place names or addresses. This process is also known as <a href="https://opencagedata.com/faq">reverse geocoding</a>. <br>The coordinates used for geocoding are appended as attributes in the output file; for information about the other attributes, please check the help.')
+        return self.tr('<p>Turn point geometries into human understandable place names or addresses. This process is also known as reverse geocoding.</p> <p>The coordinates used for geocoding are appended as attributes in the output file.</p><p>For information about the other search attributes, please check the help and <a href="https://opencagedata.com/tutorials/geocode-in-qgis">tutorial</a></p>.')
     
     def helpString(self):
         """

--- a/opencage_geocoder/ui/settings.ui
+++ b/opencage_geocoder/ui/settings.ui
@@ -34,7 +34,7 @@
       <item row="1" column="0" colspan="2">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can sign up for a key on: &lt;a href=&quot;https://opencagedata.com/pricing&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://opencagedata.com/pricing&lt;/span&gt;&lt;/a&gt; . If you register for a free trial key, please bear in mind the &lt;a href=&quot;https://opencagedata.com/api#free-trial#&quot;&gt;limitations on latency and number of daily requests&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can sign up for a key on: &lt;a href=&quot;https://opencagedata.com/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://opencagedata.com/&lt;/span&gt;&lt;/a&gt;. If you register for a free trial key, please bear in mind the &lt;a href=&quot;https://opencagedata.com/api#free-trial#&quot;&gt;limitations on latency and number of daily requests&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="scaledContents">
          <bool>false</bool>


### PR DESCRIPTION
Last documentation fixes for the initial release. It's a placeholder page right now and we'll fill it with screenshots and specific help for all the search attributes in the plugin in the next couple of days. https://opencagedata.com/tutorials/geocode-in-qgis
Since there's no other changes we can merge this PR one the tutorial page contains more content.