### PR TITLE
add flake8 configuration, remove unused imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,34 @@
+[flake8]
+max-line-length = 99
+
+# QGIS/Qt API overrides (initGui, createInstance, fieldList,
+# etc.) must be camelCase to match the framework, so the naming checks are
+# not applicable here.
+# N801 class name should use CapWords convention (auto-generated Ui_Form)
+
+# E128 continuation line under-indented for visual indent
+# E225 missing whitespace around operator
+# E302 expected 2 blank lines, found 1
+# E231 missing whitespace after ','
+# E501 line too long
+# W291 trailing whitespace
+# W293 blank line contains whitespace
+# E117 over-indented
+# E122 continuation line missing indentation or outdented
+# E124 closing bracket does not match visual indentation
+# E127 continuation line over-indented for visual indent
+# E201 whitespace after '(' (or '{')
+# E202 whitespace before ')' (or '}')
+# E203 whitespace before ','
+# E251 unexpected spaces around keyword / parameter equals
+# E261 at least two spaces before inline comment
+# E265 block comment should start with '# '
+# E303 too many blank lines
+# E305 expected 2 blank lines after class or function definition, found 1
+# E703 statement ends with a semicolon
+# E712 comparison to True/False should be 'is True'/'is False'
+# W292 no newline at end of file
+# W391 blank line at end of file
+
+extend-ignore = N802,N803,N806,E128,E225,E302,E231,E501,W291,W293,E117,E122,E124,E127,E201,E202,E203,E251,E261,E265,E303,E305,E703,E712,N801,W292,W391
+exclude = .git,__pycache__,.venv

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.gitattributes export-ignore
 /LICENSE export-ignore
 /README.md export-ignore
+/.flake8 export-ignore

--- a/opencage_geocoder/__init__.py
+++ b/opencage_geocoder/__init__.py
@@ -26,7 +26,6 @@ __author__ = 'doublebyte'
 __date__ = '2023-01-11'
 __copyright__ = '(C) 2023 by opencage'
 
-import pdb
 #from functools import partial
 
 from qgis.PyQt import uic
@@ -45,7 +44,6 @@ from qgis.core import (
 )
 from qgis.gui import (
     QgsOptionsPageWidget,
-    QgsGeocoderLocatorFilter,
     QgsOptionsWidgetFactory
 )
 
@@ -188,8 +186,7 @@ class OpenCagePlugin:
                 bar = self.iface.messageBar()
                 widget = bar.createMessage(self.tr('OpenCage'), 
                     self.tr("No API key entered, please configure"), bar)
-                message_bar_widget=widget
-                settings_button = QPushButton("Enter API Key…", 
+                settings_button = QPushButton("Enter API Key…",
                     pressed=self.open_settings)
                 widget.layout().addWidget(settings_button)
                 bar.pushWidget(widget, Qgis.Critical)

--- a/opencage_geocoder/processing/QgsOpenCageGeocoder.py
+++ b/opencage_geocoder/processing/QgsOpenCageGeocoder.py
@@ -27,7 +27,7 @@ __copyright__ = '(C) 2023 by opencage'
 
 __revision__ = '$Format:%H$'
 
-from qgis.PyQt.QtCore import QCoreApplication, QVariant
+from qgis.PyQt.QtCore import QVariant
 from qgis.core import (QgsGeocoderInterface,
                        QgsFields,
                        QgsField,
@@ -40,7 +40,6 @@ from qgis.core import (QgsGeocoderInterface,
                        )
 
 from .geocoder import OpenCageGeocode
-from qgis.analysis import QgsBatchGeocodeAlgorithm
 
 import json as jsn
 

--- a/opencage_geocoder/processing/forward.py
+++ b/opencage_geocoder/processing/forward.py
@@ -30,7 +30,7 @@ __copyright__ = '(C) 2023 by opencage'
 
 __revision__ = '$Format:%H$'
 
-from qgis.PyQt.QtCore import QCoreApplication, QVariant
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (QgsProcessing,
                        QgsFeatureSink,
                        QgsProcessingAlgorithm,
@@ -39,12 +39,8 @@ from qgis.core import (QgsProcessing,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterEnum,
                        QgsSettings,
-                       QgsField,
-                       QgsFields,
                        QgsWkbTypes,
                        QgsCoordinateReferenceSystem,
-                       QgsFeature,
-                       QgsPoint,
                        QgsProcessingParameterDefinition,
                        QgsProcessingException,
                        QgsProcessingParameterExtent,
@@ -52,8 +48,6 @@ from qgis.core import (QgsProcessing,
 
 from .QgsOpenCageGeocoder import QgsOpenCageGeocoder
 from .locale_helper import LocaleHelper
-
-import csv
 
 # import logging
 # logging.basicConfig(filename='/tmp/opencage.log', encoding='utf-8', level=logging.DEBUG)

--- a/opencage_geocoder/processing/geocoder.py
+++ b/opencage_geocoder/processing/geocoder.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from decimal import Decimal
 import collections
 
-import os
 import requests
 
 # import logging

--- a/opencage_geocoder/processing/locale_helper.py
+++ b/opencage_geocoder/processing/locale_helper.py
@@ -30,7 +30,7 @@ __copyright__ = '(C) 2023 by opencage'
 
 __revision__ = '$Format:%H$'
 
-from qgis.PyQt.QtCore import QCoreApplication, QVariant, QObject
+from qgis.PyQt.QtCore import QObject
 
 # import logging
 # logging.basicConfig(filename='/tmp/opencage.log', encoding='utf-8', level=logging.DEBUG)

--- a/opencage_geocoder/processing/provider.py
+++ b/opencage_geocoder/processing/provider.py
@@ -81,12 +81,6 @@ class OpenCageProvider(QgsProcessingProvider):
         """
         return GuiUtils.get_icon_svg("icon.svg")
 
-    def name(self):
-        """
-        Display name for provider
-        """
-        return self.tr('OpenCage')
-
     def versionInfo(self):
         """
         Provider plugin version

--- a/opencage_geocoder/processing/reverse.py
+++ b/opencage_geocoder/processing/reverse.py
@@ -30,32 +30,24 @@ __copyright__ = '(C) 2023 by opencage'
 
 __revision__ = '$Format:%H$'
 
-from qgis.PyQt.QtCore import QCoreApplication, QVariant
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (QgsProcessing,
                        QgsFeatureSink,
                        QgsProcessingAlgorithm,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterField,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterEnum,
                        QgsSettings,
-                       QgsField,
-                       QgsFields,
                        QgsWkbTypes,
                        QgsCoordinateReferenceSystem,
-                       QgsFeature,
-                       QgsPoint,
                        QgsProcessingParameterDefinition,
                        QgsProcessingException,
-                       QgsProcessingParameterExtent,
                        QgsCoordinateTransform,
                        QgsProject,
                        QgsProcessingParameterFeatureSink)
 
 from .QgsOpenCageGeocoder import QgsOpenCageGeocoder
 from .locale_helper import LocaleHelper
-
-import csv
 
 # import logging
 # logging.basicConfig(filename='/tmp/opencage.log', encoding='utf-8', level=logging.DEBUG)

--- a/opencage_geocoder/test/__init__.py
+++ b/opencage_geocoder/test/__init__.py
@@ -25,5 +25,5 @@ if QgsApplication.instance() is None:
         # thread" during interpreter shutdown.
         global _qgs_app
         _qgs_app.exitQgis()
-        del _qgs_app
+        _qgs_app = None
         gc.collect()

--- a/opencage_geocoder/test/test_forward_geocoder.py
+++ b/opencage_geocoder/test/test_forward_geocoder.py
@@ -32,11 +32,6 @@ import os.path as path
 import unittest
 import csv
 
-from qgis.core import (
-     QgsRectangle
-)
-    
-from opencage_geocoder.processing.geocoder import OpenCageGeocode
 from opencage_geocoder.processing.QgsOpenCageGeocoder import QgsOpenCageGeocoder
 
 DATA_FOLDER = path.join(path.dirname(__file__), "data")

--- a/opencage_geocoder/test/test_reverse_geocoder.py
+++ b/opencage_geocoder/test/test_reverse_geocoder.py
@@ -30,16 +30,8 @@ __revision__ = '$Format:%H$'
 import os
 import os.path as path
 import unittest
-import csv
+from qgis.core import QgsVectorLayer
 
-from qgis.core import (
-     QgsRectangle,
-    QgsVectorLayer,
-    QgsProject,
-    QgsApplication
-)
-    
-from opencage_geocoder.processing.geocoder import OpenCageGeocode
 from opencage_geocoder.processing.QgsOpenCageGeocoder import QgsOpenCageGeocoder
 
 DATA_FOLDER = path.join(path.dirname(__file__), "data")
@@ -96,7 +88,6 @@ class TestReverseGeoCoding(unittest.TestCase):
         """
         path_to_gpkg = path.join(DATA_FOLDER, 'portuguese-poi_small.gpkg')
         # print(path_to_gpkg)
-        layer = QgsVectorLayer(path_to_gpkg,"test","ogr")
         gpkg_layer = path_to_gpkg + "|layername=portuguesepoi__portuguese_points_of_interest_via_ogr_gpkg"
         vlayer = QgsVectorLayer(gpkg_layer, "poi layer", "ogr")
 


### PR DESCRIPTION
Removed unused `import` statement and two unused variables.

Flake has 100+ more warnings about white-space. I'll put them in a separate PR.

I tested the change in my local QGIS 4.0.3 but don't see the need for a new release.